### PR TITLE
Add prototype overlay network with Python relays and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# newprojects
+# Alternative WireGuard Relay Network
+
+This repository contains a minimal prototype for a relay network similar to Tor but built on Python with ephemeral key exchange. It consists of three components:
+
+- `dashboard/` – central service that keeps a list of relays.
+- `relay/` – volunteer relay server that forwards encrypted traffic.
+- `client/` – command line client capable of chat, file transfer, listing relays and pinging.
+
+## Requirements
+
+- Python 3.12
+- `cryptography`, `pynacl`, `aiohttp`, `flask`
+
+Install dependencies with:
+
+```bash
+pip install cryptography pynacl aiohttp flask
+```
+
+## Running the dashboard
+
+```
+python3 dashboard/dashboard.py
+```
+
+## Starting a relay
+
+```
+python3 relay/relay.py --host 0.0.0.0 --port 9000
+```
+
+Each relay should POST to `http://dashboard:5000/register` on startup (not implemented in this demo). The dashboard exposes `/relays` for the client to fetch available relays.
+
+## Client usage
+
+List available relays:
+
+```
+python3 client/client.py list
+```
+
+Ping relays:
+
+```
+python3 client/client.py ping
+```
+
+Chat with a peer through the network:
+
+```
+python3 client/client.py chat <host> <port> --hops 3
+```
+
+Send a file:
+
+```
+python3 client/client.py send <host> <port> <file> --hops 3
+```
+
+This code is a minimal prototype and should not be considered secure or production ready.

--- a/client/client.py
+++ b/client/client.py
@@ -1,0 +1,107 @@
+import asyncio
+import random
+import json
+import argparse
+from tunnel import handshake, encrypt_message, read_message
+import aiohttp
+
+RELAY_LIST_URL = 'http://localhost:5000/relays'
+
+async def fetch_relays():
+    async with aiohttp.ClientSession() as session:
+        async with session.get(RELAY_LIST_URL) as resp:
+            return await resp.json()
+
+async def open_chain(relays, dest_host, dest_port):
+    if not relays:
+        raise ValueError('no relays')
+    chain = [{'host': r['host'], 'port': r['port']} for r in relays[1:]]
+    reader, writer = await asyncio.open_connection(relays[0]['host'], relays[0]['port'])
+    info = {'chain': chain, 'target_host': dest_host, 'target_port': dest_port}
+    box = await handshake(reader, writer, initiator=True, info=info)
+    return reader, writer, box
+
+async def chat(dest_host, dest_port, hop_count=3):
+    relays = await fetch_relays()
+    random.shuffle(relays)
+    selected = relays[:hop_count]
+    reader, writer, box = await open_chain(selected, dest_host, dest_port)
+    print('Connected to chat peer. type messages:')
+    async def read_loop():
+        while True:
+            data = await read_message(reader, box)
+            if data is None:
+                break
+            print('peer:', data.decode())
+    asyncio.create_task(read_loop())
+    try:
+        while True:
+            msg = await asyncio.get_event_loop().run_in_executor(None, input)
+            if not msg:
+                break
+            writer.write(encrypt_message(box, msg.encode()))
+            await writer.drain()
+    finally:
+        writer.close()
+
+async def send_file(dest_host, dest_port, path, hop_count=3):
+    relays = await fetch_relays()
+    random.shuffle(relays)
+    selected = relays[:hop_count]
+    reader, writer, box = await open_chain(selected, dest_host, dest_port)
+    with open(path, 'rb') as f:
+        while True:
+            chunk = f.read(4096)
+            if not chunk:
+                break
+            writer.write(encrypt_message(box, chunk))
+            await writer.drain()
+    writer.write(encrypt_message(box, b''))
+    await writer.drain()
+    writer.close()
+
+async def ping_relays(count=1):
+    relays = await fetch_relays()
+    results = []
+    for r in relays:
+        try:
+            reader, writer = await asyncio.open_connection(r['host'], r['port'])
+            box = await handshake(reader, writer, initiator=True, info={'ping': True})
+            writer.close()
+            results.append((r, 'ok'))
+        except Exception as e:
+            results.append((r, 'fail'))
+    for r, res in results:
+        print(f"{r['host']}:{r['port']} -> {res}")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest='cmd')
+    chat_p = sub.add_parser('chat')
+    chat_p.add_argument('host')
+    chat_p.add_argument('port', type=int)
+    chat_p.add_argument('--hops', type=int, default=3)
+
+    send_p = sub.add_parser('send')
+    send_p.add_argument('host')
+    send_p.add_argument('port', type=int)
+    send_p.add_argument('file')
+    send_p.add_argument('--hops', type=int, default=3)
+
+    sub.add_parser('list')
+    sub.add_parser('ping')
+
+    args = parser.parse_args()
+
+    if args.cmd == 'list':
+        relays = asyncio.run(fetch_relays())
+        for r in relays:
+            print(r['host'], r['port'])
+    elif args.cmd == 'ping':
+        asyncio.run(ping_relays())
+    elif args.cmd == 'chat':
+        asyncio.run(chat(args.host, args.port, args.hops))
+    elif args.cmd == 'send':
+        asyncio.run(send_file(args.host, args.port, args.file, args.hops))
+    else:
+        parser.print_help()

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -1,0 +1,32 @@
+from flask import Flask, request, jsonify
+import time
+
+app = Flask(__name__)
+relays = {}
+
+@app.route('/register', methods=['POST'])
+def register():
+    data = request.json
+    key = f"{data['host']}:{data['port']}"
+    relays[key] = {'host': data['host'], 'port': data['port'], 'last': time.time()}
+    return 'ok'
+
+@app.route('/heartbeat', methods=['POST'])
+def heartbeat():
+    data = request.json
+    key = f"{data['host']}:{data['port']}"
+    if key in relays:
+        relays[key]['last'] = time.time()
+    return 'ok'
+
+@app.route('/relays', methods=['GET'])
+def list_relays():
+    now = time.time()
+    return jsonify([v for v in relays.values() if now - v['last'] < 60])
+
+@app.route('/stats', methods=['GET'])
+def stats():
+    return jsonify({'relay_count': len(relays)})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0')

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -1,0 +1,75 @@
+import asyncio
+import json
+import argparse
+from tunnel import handshake, encrypt_message, read_message
+
+async def forward(reader, writer, in_box, out_box):
+    while True:
+        data = await read_message(reader, in_box)
+        if data is None:
+            break
+        writer.write(encrypt_message(out_box, data))
+        await writer.drain()
+    writer.close()
+
+async def handle_client(reader, writer, register_callback):
+    try:
+        in_box, info = await handshake(reader, writer, initiator=False)
+        chain = info.get('chain', [])
+        target_host = info.get('target_host')
+        target_port = info.get('target_port')
+        if chain:
+            next_hop = chain.pop(0)
+            next_info = {'chain': chain, 'target_host': target_host, 'target_port': target_port}
+            next_reader, next_writer = await asyncio.open_connection(next_hop['host'], next_hop['port'])
+            out_box = await handshake(next_reader, next_writer, initiator=True, info=next_info)
+        else:
+            next_reader, next_writer = await asyncio.open_connection(target_host, target_port)
+            out_box = None
+        await register_callback(True)
+        if out_box:
+            await asyncio.gather(
+                forward(reader, next_writer, in_box, out_box),
+                forward(next_reader, writer, out_box, in_box)
+            )
+        else:
+            # final hop
+            async def to_target():
+                while True:
+                    data = await read_message(reader, in_box)
+                    if data is None:
+                        break
+                    next_writer.write(data)
+                    await next_writer.drain()
+                next_writer.close()
+            async def from_target():
+                while True:
+                    data = await next_reader.read(4096)
+                    if not data:
+                        break
+                    writer.write(encrypt_message(in_box, data))
+                    await writer.drain()
+                writer.close()
+            await asyncio.gather(to_target(), from_target())
+    except Exception as e:
+        print('error:', e)
+    finally:
+        await register_callback(False)
+        writer.close()
+
+async def run_server(host, port, register_callback):
+    server = await asyncio.start_server(lambda r, w: handle_client(r, w, register_callback), host, port)
+    print(f'Relay running on {host}:{port}')
+    async with server:
+        await server.serve_forever()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--host', default='0.0.0.0')
+    parser.add_argument('--port', type=int, default=9000)
+    args = parser.parse_args()
+
+    async def dummy(active):
+        pass
+
+    asyncio.run(run_server(args.host, args.port, dummy))

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -1,0 +1,24 @@
+import os, sys; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import asyncio
+import pytest
+import tunnel
+
+async def handle(r, w):
+    box, _ = await tunnel.handshake(r, w, initiator=False)
+    msg = await tunnel.read_message(r, box)
+    w.write(tunnel.encrypt_message(box, msg))
+    await w.drain()
+    w.close()
+
+@pytest.mark.asyncio
+async def test_handshake():
+    server = await asyncio.start_server(handle, '127.0.0.1', 0)
+    host, port = server.sockets[0].getsockname()
+    async with server:
+        reader, writer = await asyncio.open_connection(host, port)
+        box = await tunnel.handshake(reader, writer, initiator=True, info={})
+        writer.write(tunnel.encrypt_message(box, b'ping'))
+        await writer.drain()
+        reply = await tunnel.read_message(reader, box)
+        assert reply == b'ping'
+        writer.close()

--- a/tunnel.py
+++ b/tunnel.py
@@ -1,0 +1,43 @@
+import asyncio
+import struct
+import json
+from nacl.public import PrivateKey, PublicKey, Box
+from nacl.utils import random as random_bytes
+
+async def handshake(reader, writer, initiator=True, info=None):
+    if initiator:
+        priv = PrivateKey.generate()
+        writer.write(priv.public_key.encode())
+        await writer.drain()
+        peer_pub = await reader.read(32)
+        box = Box(priv, PublicKey(peer_pub))
+        payload = json.dumps(info or {}).encode()
+        encrypted = box.encrypt(payload)
+        writer.write(struct.pack('!I', len(encrypted)) + encrypted)
+        await writer.drain()
+        return box
+    else:
+        peer_pub = await reader.read(32)
+        priv = PrivateKey.generate()
+        writer.write(priv.public_key.encode())
+        await writer.drain()
+        box = Box(priv, PublicKey(peer_pub))
+        length_bytes = await reader.read(4)
+        if len(length_bytes) < 4:
+            raise ConnectionError('handshake failed')
+        length = struct.unpack('!I', length_bytes)[0]
+        encrypted = await reader.read(length)
+        payload = json.loads(box.decrypt(encrypted))
+        return box, payload
+
+def encrypt_message(box, data):
+    enc = box.encrypt(data)
+    return struct.pack('!I', len(enc)) + enc
+
+async def read_message(reader, box):
+    len_bytes = await reader.read(4)
+    if not len_bytes:
+        return None
+    length = struct.unpack('!I', len_bytes)[0]
+    enc = await reader.read(length)
+    return box.decrypt(enc)


### PR DESCRIPTION
## Summary
- develop a small prototype for a relay-based network
- implement relay server and client with ephemeral key exchange
- add a simple Flask dashboard for relay listing
- provide unit test for handshake logic
- document how to run the components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c3720ff08321a05984c3bdf83251